### PR TITLE
Fix getFriends method

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -171,7 +171,7 @@ class Client {
      * @returns {Promise|undefined} - undefined if callback defined, Promise if no callback
      */
     getFriends(player, callback) {
-        return this._request('friends', { player }, 'records', callback);
+        return this._request('friends', { uuid: player }, 'records', callback);
     }
 
     /**


### PR DESCRIPTION
Fixed issue where the getFriends method was requesting with datta: {player: 'UUID'} rather than: {uuid: 'UUID'}.

Simple fix for a pretty large bug :)